### PR TITLE
Using HTTPS for Flattr urls

### DIFF
--- a/chrome/ressources/banner/banner.html
+++ b/chrome/ressources/banner/banner.html
@@ -11,8 +11,8 @@
             </form>
         </div>
 		<div>
-			<a href="http://flattr.com/thing/888156/ProxMate-unblock-the-Internet" target="_blank">
-				<img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" />
+			<a href="https://flattr.com/thing/888156/ProxMate-unblock-the-Internet" target="_blank">
+				<img src="https://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" />
 			</a>
 		</div>
 

--- a/firefox/data/elements/banner.html
+++ b/firefox/data/elements/banner.html
@@ -24,8 +24,8 @@
 	<div class="pmElement">
 		<p class="pmElementTitle">Flattr:</p>
 		<div class="pmElementContent">
-			<a href="http://flattr.com/thing/888156/ProxMate-unblock-the-Internet" target="_blank">
-			<img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a>
+			<a href="https://flattr.com/thing/888156/ProxMate-unblock-the-Internet" target="_blank">
+			<img src="https://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a>
 		</div>
 	</div>
 	<div class="pmElement">


### PR DESCRIPTION
Using HTTP makes google chrome load https://www.netflix.com with an yellow icon indicating that it is loading mixed content(secured and unsecured). Changing it to HTTPS to avoid that warning.
